### PR TITLE
Fix typos, improve readability and consistency in exercise instructions

### DIFF
--- a/exercises/E-strings-concatenation/exercise.js
+++ b/exercises/E-strings-concatenation/exercise.js
@@ -1,3 +1,3 @@
-// Start by creating a variable `message`
+// Start by creating a variable to begin the greeting
 
-console.log(message);
+console.log(greeting);

--- a/exercises/F-strings-methods/exercise.js
+++ b/exercises/F-strings-methods/exercise.js
@@ -1,3 +1,3 @@
-// Start by creating a variable `message`
+// Start by creating a variable `name`
 
-console.log(message);
+console.log(name);

--- a/exercises/F-strings-methods/exercise2.js
+++ b/exercises/F-strings-methods/exercise2.js
@@ -1,3 +1,3 @@
-const name = " Daniel  ";
+var name = " Daniel  ";
 
 console.log(message);

--- a/exercises/G-numbers/README.md
+++ b/exercises/G-numbers/README.md
@@ -25,5 +25,5 @@ var difference = 10 - 2; // 8
 ```
 Number of students: 15
 Number of mentors: 8
-Total numnber of students and mentors: 23
+Total number of students and mentors: 23
 ```

--- a/exercises/I-floats/README.md
+++ b/exercises/I-floats/README.md
@@ -13,11 +13,11 @@ var roughAge = Math.round(preciseAge); // 30
 
 ## Exercise
 
-* Using the variables provided in the exercise calculate the percentage of mentors and students in the group
+* Using the variables provided in the exercise calculate the percentage of mentors and students in the group as whole numbers
 
 ## Expected result
 
 ```
-Percentage students: 65%
-Percentage mentors: 35%
+65% are students
+35% are mentors
 ```

--- a/exercises/K-functions-parameters/README.md
+++ b/exercises/K-functions-parameters/README.md
@@ -10,7 +10,7 @@ function add(a, b) {
 
 When you write a function (sometimes called _declaring a function_) you assign names to the parameters inside of the parentheses (`()`). Parameters can be called anything.
 
-This function is exactly the same as the on above:
+This function is exactly the same as the one above:
 
 ```js
 function add(num1, num2) {

--- a/exercises/L-functions-nested/README.md
+++ b/exercises/L-functions-nested/README.md
@@ -9,7 +9,7 @@ function getAgeInDays(age) {
   return age * 365;
 }
 
-function createCreeting(name, age) {
+function createGreeting(name, age) {
   var ageInDays = getAgeInDays(age);
   var message =
     "My Name is " + name + " and I was born over " + ageInDays + " days ago!";
@@ -20,7 +20,7 @@ function createCreeting(name, age) {
 ## Exercise 1
 
 - In `exercise.js` write a program that displays the percentage of students and mentors in the group
-- The percentage should be rounded to the nearest whole number (use a search engine to find out how to this with JavaScript)
+- The percentage should be rounded to the nearest whole number (see exercise `I-floats` for a reminder of how to do this)
 - You should have one function that calculates the percentage, and one function that creates a message
 
 > Consider: should your percentage function do the rounding, or should it be done when the greeting is created?
@@ -28,8 +28,8 @@ function createCreeting(name, age) {
 ## Expected result
 
 ```
-Percentage students: 65%
-Percentage mentors: 35%
+65% are students
+35% are mentors
 ```
 
 ## Exercise 2

--- a/exercises/L-functions-nested/exercise.js
+++ b/exercises/L-functions-nested/exercise.js
@@ -1,5 +1,4 @@
-var mentor1 = "Daniel";
-var mentor2 = "Irina";
-var mentor3 = "Mimi";
-var mentor4 = "Rob";
-var mentor5 = "Yohannes";
+var numberOfStudents = 15;
+var numberOfMentors = 8;
+
+// Start by creating functions for calculating percentages

--- a/exercises/L-functions-nested/exercise2.js
+++ b/exercises/L-functions-nested/exercise2.js
@@ -1,0 +1,5 @@
+var mentor1 = "Daniel";
+var mentor2 = "Irina";
+var mentor3 = "Mimi";
+var mentor4 = "Rob";
+var mentor5 = "Yohannes";

--- a/extra/2-piping.js
+++ b/extra/2-piping.js
@@ -11,7 +11,7 @@
   - add 10 to startingValue
   - multiply the result by 2
   - format it
-  
+
   3. Write a more readable version of what you wrote in step 2 under the BETTER PRACTICE comment. Assign
   the final result to the variable goodCode
 */
@@ -28,16 +28,16 @@ function format() {
 
 }
 
-const startingValue = 2
+var startingValue = 2
 
 // Why can this code be seen as bad practice? Comment your answer.
-let badCode = 
+var badCode =
 
 /* BETTER PRACTICE */
 
-let goodCode = 
+var goodCode =
 
-/* ======= TESTS - DO NOT MODIFY ===== 
+/* ======= TESTS - DO NOT MODIFY =====
 There are some Tests in this file that will help you work out if your code is working.
 
 To run these tests type `node 2-piping.js` into your terminal
@@ -46,14 +46,14 @@ To run these tests type `node 2-piping.js` into your terminal
 const util = require('util');
 
 function test(test_name, actual, expected) {
-    let status;
-    if (actual === expected) {
-        status = "PASSED";
-    } else {
-        status = `FAILED: expected: ${util.inspect(expected)} but your code returned: ${util.inspect(actual)}`;
-    }
+  let status;
+  if (actual === expected) {
+    status = "PASSED";
+  } else {
+    status = `FAILED: expected: ${util.inspect(expected)} but your code returned: ${util.inspect(actual)}`;
+  }
 
-    console.log(`${test_name}: ${status}`);
+  console.log(`${test_name}: ${status}`);
 }
 
 test('add function - case 1 works', add(1,3), 4)


### PR DESCRIPTION
This PR predominantly fixes a couple of typos and matches `exercise.js` contents up to their `README`s.

There's also some code consistency tweaks e.g. consistent use `var` instead of some sporadic use of `let`/`const`. This might be not what we want given general industry preferences for using `let`/`const` over `var` going forwards but I think the consistency probably most important unless it is explicitly taught somewhere.

