### PR TITLE
Rename the function to be more explicit

### DIFF
--- a/mandatory/4-tax.js
+++ b/mandatory/4-tax.js
@@ -5,7 +5,7 @@
   Sales tax is 20% of the price of the product.
 */
 
-function calculateSalesTax() {}
+function addSalesTax() {}
 
 /*
   CURRENCY FORMATTING
@@ -31,15 +31,15 @@ To run the tests for just this one file, type `npm test -- --testPathPattern 4-t
 */
 
 test("calculateSalesTax for £15", () => {
-  expect(calculateSalesTax(15)).toEqual(18);
+  expect(addSalesTax(15)).toEqual(18);
 });
 
 test("calculateSalesTax for £17.50", () => {
-  expect(calculateSalesTax(17.5)).toEqual(21);
+  expect(addSalesTax(17.5)).toEqual(21);
 });
 
 test("calculateSalesTax for £34", () => {
-  expect(calculateSalesTax(34)).toEqual(40.8);
+  expect(addSalesTax(34)).toEqual(40.8);
 });
 
 test("addTaxAndFormatCurrency for £15", () => {


### PR DESCRIPTION
## What is this changing?

from `calculateSalesTax` to `addSalesTax`.

## Why?

The current name can be confusing, as it suggests that the returned value should be the sales tax, when in fact it should compound it to the original price.