### PR TITLE
describe tests in README; use jest projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The `extra` folder contains exercises that you can complete to challenge yoursel
 
 ## Running the code/tests
 
-These files for the mandatory/extra exercises are intended to be run as jest tests. 
+The files for the mandatory/extra exercises are intended to be run as jest tests. 
 
 - Once you have cloned the repository, run `npm install` once in the terminal to install jest (and any necessary dependencies).
 - To run the tests for all mandatory/extra exercises, run `npm test`

--- a/README.md
+++ b/README.md
@@ -6,6 +6,26 @@ The exercises are split into three folders: `exercises`, `mandatory` and `extra`
 
 The `extra` folder contains exercises that you can complete to challenge yourself, but are not required for the following lesson.
 
+## Running the code/tests
+
+These files for the mandatory/extra exercises are intended to be run as jest tests. 
+
+- Once you have cloned the repository, run `npm install` once in the terminal to install jest (and any necessary dependencies).
+- To run the tests for all mandatory/extra exercises, run `npm test`
+- To run only the tests for the mandatory exercises, run `npm test -- --selectProjects mandatory`
+- To run only the tests for the extra exercises, run `npm test -- --selectProjects extra`
+- To run a single exercise/test (for example `mandatory/1-writer.js`), run `npm test -- --testPathPattern mandatory/1-writer.js` (Remember, you can use tab-completion to get files relative to the current directory, so m`Tab ↹`/1-`Tab ↹` will autocomplete get you the test file starting with 1-)
+
+For more information about tests, look here:
+
+https://syllabus.codeyourfuture.io/guides/intro-to-tests
+
+Try out variant way of running tests:
+
+- `npm test` -> run all mandatory and extra tests
+- `npm test -- --selectProjects mandatory` -> run only mandatory tests
+- `npm test -- --testPathPattern mandatory/1-syntax-errors.js` -> run single test
+
 ## Solutions
 
 The solutions for this coursework can be found here:

--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "version": "1.0.0",
   "description": "Exercises for JS1 Week 1",
   "scripts": {
-    "test": "jest --testRegex='mandatory[/\\\\].*\\.js$'",
-    "extra-tests": "jest --testRegex='extra[/\\\\].*\\.js$'"
+    "test": "jest"
   },
   "repository": {
     "type": "git",
@@ -14,7 +13,17 @@
     "url": "https://github.com/CodeYourFuture/JavaScript-Core-1-Coursework-Week1/issues"
   },
   "jest": {
-    "setupFilesAfterEnv": ["jest-extended"]
+    "setupFilesAfterEnv": ["jest-extended"],
+    "projects": [
+      {
+        "displayName": "mandatory",
+        "testMatch": ["<rootDir>/mandatory/*.js"]
+      },
+      {
+        "displayName": "extra",
+        "testMatch": ["<rootDir>/extra/*.js"]
+      }
+    ]
   },
   "homepage": "https://github.com/CodeYourFuture/JavaScript-Core-1-Coursework-Week1#readme",
   "devDependencies": {


### PR DESCRIPTION
npm test now runs all tests. Running only the mandatory tests is described in the README.

Suggestion for when we have auto running of tests on commit would be to add an npm script that is run with `npm run post-commit` or something like that (that would only run the mandatory tests and not the extra?)

-----
[View rendered README.md](https://github.com/CodeYourFuture/JavaScript-Core-1-Coursework-Week1/blob/readme_js1wk1/README.md)